### PR TITLE
 error: variable i set but not used fix

### DIFF
--- a/src/msdfgl.c
+++ b/src/msdfgl.c
@@ -960,7 +960,7 @@ void msdfgl_geometry(float *x, float *y, msdfgl_font_t font, float size,
 
     size_t buf_idx = 0;
     GLint prev_key = -1;
-    for (size_t i = 0; buf_idx < bufsize; ++i) {
+    while (buf_idx < bufsize) {
         GLint key;
 
         if (flags & MSDFGL_WCHAR)


### PR DESCRIPTION
meant to fix this error, as cmake is using to treat all warnings as errors
```c++
/Users/d/src/msdfgl/src/msdfgl.c:963:17: error: variable 'i' set but not used [-Werror,-Wunused-but-set-variable]
  963 |     for (size_t i = 0; buf_idx < bufsize; ++i) {
      |                 ^

```